### PR TITLE
Add optional EXTRA_CPPFLAGS in makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 CC ?= gcc  # version?
 CXX ?= g++
-CPPFLAGS = -std=c++17
+CPPFLAGS = -std=c++17 $(EXTRA_CPPFLAGS)
 
 # Add new source files here.
 SRCS = lexer.cpp parser.cpp


### PR DESCRIPTION
This allows us to provide extra flags to be passed to compile and link invocations.