### PR TITLE
Fix String Literals to Handle Newline.

### DIFF
--- a/lexer.cpp
+++ b/lexer.cpp
@@ -62,19 +62,16 @@ Result<Token> Lexer::LexImpl() {
   }
 
   if (ch == '"') {
+    // FIXME(PiJoules): We should also test for EOF here.
     std::string quoted_str;
     ch = getNextChar();
-    int prev = -1;
     while (ch != '"') {
-      // FIXME(PiJoules): We should also test for EOF here.
-      if (ch == 'n' && prev == '\\') {
+      if (ch == 'n' && !quoted_str.empty() && quoted_str.back() == '\\') {
         quoted_str.back() = '\n';
-        prev = -1;
         ch = getNextChar();
         continue;
       }
       quoted_str += static_cast<char>(ch);
-      prev = ch;
       ch = getNextChar();
     }
     return Token(Token::string, row, col, quoted_str);

--- a/lexer.cpp
+++ b/lexer.cpp
@@ -64,9 +64,17 @@ Result<Token> Lexer::LexImpl() {
   if (ch == '"') {
     std::string quoted_str;
     ch = getNextChar();
+    int prev = -1;
     while (ch != '"') {
       // FIXME(PiJoules): We should also test for EOF here.
+      if (ch == 'n' && prev == '\\') {
+        quoted_str.back() = '\n';
+        prev = -1;
+        ch = getNextChar();
+        continue;
+      }
       quoted_str += static_cast<char>(ch);
+      prev = ch;
       ch = getNextChar();
     }
     return Token(Token::string, row, col, quoted_str);

--- a/test.cpp
+++ b/test.cpp
@@ -6,8 +6,9 @@
 
 namespace {
 
-constexpr char kHelloWorldStr[] = "main( () => () )\n"
-                                  "  out \"Hello World\"";
+constexpr char kHelloWorldStr[] =
+    "main( () => () )\n"
+    "  out \"Hello World\"";
 
 TEST(Lexer, HelloWorld) {
   std::stringstream ss(kHelloWorldStr);
@@ -209,4 +210,4 @@ TEST(Result, ErrornessIndependentOfValue) {
   ASSERT_TRUE(s_err.hasError());
 }
 
-} // namespace
+}  // namespace

--- a/test.cpp
+++ b/test.cpp
@@ -29,6 +29,36 @@ TEST(Lexer, HelloWorld) {
   ASSERT_EQ(lexer.Lex().get(), xos::Token(xos::Token::eof, 2, 20));
 }
 
+TEST(Lexer, ExpectEndlineCharacterAtLastChar) {
+  char helloWorldStr[] = "\"Hello World\n\"";
+  std::stringstream ss(helloWorldStr);
+  xos::Lexer lexer(ss);
+  std::string expectedString = "Hello World";
+  expectedString.push_back('\n');
+  ASSERT_EQ(lexer.Lex().get(),
+            xos::Token(xos::Token::string, 1, 1, expectedString));
+}
+
+TEST(Lexer, ExpectEndlineCharacterAtFirstChar) {
+  char helloWorldStr[] = "\"\nHello World\"";
+  std::stringstream ss(helloWorldStr);
+  xos::Lexer lexer(ss);
+  std::string expectedString = "Hello World";
+  expectedString.insert(0, 1, '\n');
+  ASSERT_EQ(lexer.Lex().get(),
+            xos::Token(xos::Token::string, 1, 1, expectedString));
+}
+
+TEST(Lexer, ExpectEndlineCharacterAtSixthChar) {
+  char helloWorldStr[] = "\"Hello\n World\"";
+  std::stringstream ss(helloWorldStr);
+  xos::Lexer lexer(ss);
+  std::string expectedString = "Hello World";
+  expectedString.insert(5, 1, '\n');
+  ASSERT_EQ(lexer.Lex().get(),
+            xos::Token(xos::Token::string, 1, 1, expectedString));
+}
+
 TEST(Lexer, Peek) {
   std::stringstream ss(kHelloWorldStr);
   xos::Lexer lexer(ss);

--- a/test.cpp
+++ b/test.cpp
@@ -30,33 +30,30 @@ TEST(Lexer, HelloWorld) {
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtLastChar) {
-  char helloWorldStr[] = "\"Hello World\\n\"";
+  constexpr char helloWorldStr[] = "\"Hello World\\n\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
-  std::string expectedStr = "Hello World";
-  expectedStr.push_back('\n');
+  std::string_view expectedStr = "Hello World\n";
   ASSERT_EQ(lexer.Lex().get(),
-            xos::Token(xos::Token::string, 1, 1, expectedStr));
+            xos::Token(xos::Token::string, 1, 1, expectedStr.data()));
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtFirstChar) {
-  char helloWorldStr[] = "\"\\nHello World\"";
+  constexpr char helloWorldStr[] = "\"\\nHello World\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
-  std::string expectedStr = "Hello World";
-  expectedStr.insert(0, 1, '\n');
+  std::string_view expectedStr = "\nHello World";
   ASSERT_EQ(lexer.Lex().get(),
-            xos::Token(xos::Token::string, 1, 1, expectedStr));
+            xos::Token(xos::Token::string, 1, 1, expectedStr.data()));
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtSixthChar) {
-  char helloWorldStr[] = "\"Hello\\n World\"";
+  constexpr char helloWorldStr[] = "\"Hello\\n World\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
-  std::string expectedStr = "Hello World";
-  expectedStr.insert(5, 1, '\n');
+  std::string_view expectedStr = "Hello\n World";
   ASSERT_EQ(lexer.Lex().get(),
-            xos::Token(xos::Token::string, 1, 1, expectedStr));
+            xos::Token(xos::Token::string, 1, 1, expectedStr.data()));
 }
 
 TEST(Lexer, Peek) {

--- a/test.cpp
+++ b/test.cpp
@@ -6,9 +6,8 @@
 
 namespace {
 
-constexpr char kHelloWorldStr[] =
-    "main( () => () )\n"
-    "  out \"Hello World\"";
+constexpr char kHelloWorldStr[] = "main( () => () )\n"
+                                  "  out \"Hello World\"";
 
 TEST(Lexer, HelloWorld) {
   std::stringstream ss(kHelloWorldStr);
@@ -33,30 +32,30 @@ TEST(Lexer, ExpectEndlineCharacterAtLastChar) {
   char helloWorldStr[] = "\"Hello World\\n\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
-  std::string expectedString = "Hello World";
-  expectedString.push_back('\n');
+  std::string expectedStr = "Hello World";
+  expectedStr.push_back('\n');
   ASSERT_EQ(lexer.Lex().get(),
-            xos::Token(xos::Token::string, 1, 1, expectedString));
+            xos::Token(xos::Token::string, 1, 1, expectedStr));
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtFirstChar) {
   char helloWorldStr[] = "\"\\nHello World\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
-  std::string expectedString = "Hello World";
-  expectedString.insert(0, 1, '\n');
+  std::string expectedStr = "Hello World";
+  expectedStr.insert(0, 1, '\n');
   ASSERT_EQ(lexer.Lex().get(),
-            xos::Token(xos::Token::string, 1, 1, expectedString));
+            xos::Token(xos::Token::string, 1, 1, expectedStr));
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtSixthChar) {
   char helloWorldStr[] = "\"Hello\\n World\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
-  std::string expectedString = "Hello World";
-  expectedString.insert(5, 1, '\n');
+  std::string expectedStr = "Hello World";
+  expectedStr.insert(5, 1, '\n');
   ASSERT_EQ(lexer.Lex().get(),
-            xos::Token(xos::Token::string, 1, 1, expectedString));
+            xos::Token(xos::Token::string, 1, 1, expectedStr));
 }
 
 TEST(Lexer, Peek) {
@@ -210,4 +209,4 @@ TEST(Result, ErrornessIndependentOfValue) {
   ASSERT_TRUE(s_err.hasError());
 }
 
-}  // namespace
+} // namespace

--- a/test.cpp
+++ b/test.cpp
@@ -6,9 +6,8 @@
 
 namespace {
 
-constexpr char kHelloWorldStr[] =
-    "main( () => () )\n"
-    "  out \"Hello World\"";
+constexpr char kHelloWorldStr[] = "main( () => () )\n"
+                                  "  out \"Hello World\"";
 
 TEST(Lexer, HelloWorld) {
   std::stringstream ss(kHelloWorldStr);
@@ -30,7 +29,7 @@ TEST(Lexer, HelloWorld) {
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtLastChar) {
-  char helloWorldStr[] = "\"Hello World\n\"";
+  char helloWorldStr[] = "\"Hello World\\n\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
   std::string expectedString = "Hello World";
@@ -40,7 +39,7 @@ TEST(Lexer, ExpectEndlineCharacterAtLastChar) {
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtFirstChar) {
-  char helloWorldStr[] = "\"\nHello World\"";
+  char helloWorldStr[] = "\"\\nHello World\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
   std::string expectedString = "Hello World";
@@ -50,7 +49,7 @@ TEST(Lexer, ExpectEndlineCharacterAtFirstChar) {
 }
 
 TEST(Lexer, ExpectEndlineCharacterAtSixthChar) {
-  char helloWorldStr[] = "\"Hello\n World\"";
+  char helloWorldStr[] = "\"Hello\\n World\"";
   std::stringstream ss(helloWorldStr);
   xos::Lexer lexer(ss);
   std::string expectedString = "Hello World";
@@ -210,4 +209,4 @@ TEST(Result, ErrornessIndependentOfValue) {
   ASSERT_TRUE(s_err.hasError());
 }
 
-}  // namespace
+} // namespace


### PR DESCRIPTION
Converts newline representation to its character form.